### PR TITLE
Update cli-support.adoc

### DIFF
--- a/learn-more/cli-support.adoc
+++ b/learn-more/cli-support.adoc
@@ -22,7 +22,6 @@ The following commands and command sets are not supported on ASA on r2:
 ====
 * `lun copy`
 * `lun geometry`
-* `lun import`
 * `lun mapping add-reportng-nodes`
 * `lun mapping-remove-reporting-nodes`
 * `lun maxsize`


### PR DESCRIPTION
Remove the 'lun import' command from the list of Unsupported 'lun' commands as they are supported from Ontap 9.17.1